### PR TITLE
refactor: remove environment variable dependency and use network selection state

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ A demonstration of Immutable Passport integration with SvelteKit.
 Create a `.env` file in the project root with the following variables:
 
 ```env
-# Environment (TESTNET or PRODUCTION)
-VITE_IMMUTABLE_ENVIRONMENT=TESTNET
-
 # Testnet Configuration
 VITE_IMMUTABLE_TESTNET_CLIENT_ID=your_testnet_client_id
 VITE_IMMUTABLE_TESTNET_PUBLISHABLE_KEY=your_testnet_publishable_key

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -333,35 +333,14 @@
   }
 
   onMount(() => {
-    const environment = import.meta.env.VITE_IMMUTABLE_ENVIRONMENT;
-    if (!environment) {
-      console.error('VITE_IMMUTABLE_ENVIRONMENT is not set');
-      result = {
-        error: 'VITE_IMMUTABLE_ENVIRONMENT is not set. Please check your .env file.'
-      };
-      return;
-    }
-
-    const isMainnet = environment === 'PRODUCTION';
-    currentNetwork = isMainnet ? 'mainnet' : 'testnet';
+    // Initialize with testnet by default
+    currentNetwork = 'testnet';
+    const isMainnet = false;
     
-    // Initialize Passport instance
     passportInstance = initializePassportInstance(isMainnet);
-    if (!passportInstance) {
-      console.error('Failed to initialize Passport instance');
-      result = {
-        error: 'Failed to initialize Passport. Please check your environment variables.'
-      };
-      return;
+    if (passportInstance) {
+      initializeProviders();
     }
-
-    // Initialize providers only if Passport instance is successfully created
-    initializeProviders().catch(error => {
-      console.error('Failed to initialize providers:', error);
-      result = {
-        error: `Failed to initialize providers: ${error instanceof Error ? error.message : 'Unknown error'}`
-      };
-    });
   });
 
   // Network switching function


### PR DESCRIPTION
## Changes
- Remove VITE_IMMUTABLE_ENVIRONMENT dependency
- Initialize app with testnet by default
- Use network selection state to determine environment
- Update README to reflect environment variable changes

## Why
- Simplify configuration by removing unnecessary environment variable
- Make network selection more intuitive
- Improve user experience with default testnet initialization